### PR TITLE
feat(prepare): add support for bumping package build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following instructions are referenced from the [documentation](https://dart.
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `cli`               | The `dart` or `flutter` CLI to use to publish the package to the registry.                                                                                                | `dart`  |
 | `publishPub`        | Whether to publish the package to the registry. If set to `false`, the `pubspec.yaml` version will still be updated.                                                      | `true`  |
-| `updateBuildNumber` | Whether to write version code for every newly bumped version in `pubspec.yaml` ([Learn more](https://developer.android.com/studio/publish/versioning#versioningsettings)) | `false` |
+| `updateBuildNumber` | Whether to write build number for every newly bumped version in `pubspec.yaml` ([Learn more](https://docs.flutter.dev/deployment/android#updating-the-apps-version-number)) | `false` |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following instructions are referenced from the [documentation](https://dart.
 |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `cli`               | The `dart` or `flutter` CLI to use to publish the package to the registry.                                                                                                | `dart`  |
 | `publishPub`        | Whether to publish the package to the registry. If set to `false`, the `pubspec.yaml` version will still be updated.                                                      | `true`  |
-| `updateBuildNumber` | Whether to write build number for every newly bumped version in `pubspec.yaml` ([Learn more](https://docs.flutter.dev/deployment/android#updating-the-apps-version-number)) | `false` |
+| `updateBuildNumber` | Whether to write build number for every newly bumped version in `pubspec.yaml`. Note that the build number will always be increased by one. Learn more on [Flutter docs](https://docs.flutter.dev/deployment/android#updating-the-apps-version-number). | `false` |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ The following instructions are referenced from the [documentation](https://dart.
 
 ### Options
 
-| Option           | Description                                                                                                                                                               | Default |
-|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `cli`            | The `dart` or `flutter` CLI to use to publish the package to the registry.                                                                                                | `dart`  |
-| `publishPub`     | Whether to publish the package to the registry. If set to `false`, the `pubspec.yaml` version will still be updated.                                                      | `true`  |
-| `useVersionCode` | Whether to write version code for every newly bumped version in `pubspec.yaml` ([Learn more](https://developer.android.com/studio/publish/versioning#versioningsettings)) | `false` |
+| Option              | Description                                                                                                                                                               | Default |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `cli`               | The `dart` or `flutter` CLI to use to publish the package to the registry.                                                                                                | `dart`  |
+| `publishPub`        | Whether to publish the package to the registry. If set to `false`, the `pubspec.yaml` version will still be updated.                                                      | `true`  |
+| `updateBuildNumber` | Whether to write version code for every newly bumped version in `pubspec.yaml` ([Learn more](https://developer.android.com/studio/publish/versioning#versioningsettings)) | `false` |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ The following instructions are referenced from the [documentation](https://dart.
 
 ### Options
 
-| Option       | Description                                                                                                          | Default |
-| ------------ | -------------------------------------------------------------------------------------------------------------------- | ------- |
-| `cli`        | The `dart` or `flutter` CLI to use to publish the package to the registry.                                           | `dart`  |
-| `publishPub` | Whether to publish the package to the registry. If set to `false`, the `pubspec.yaml` version will still be updated. | `true`  |
+| Option           | Description                                                                                                                                                               | Default |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `cli`            | The `dart` or `flutter` CLI to use to publish the package to the registry.                                                                                                | `dart`  |
+| `publishPub`     | Whether to publish the package to the registry. If set to `false`, the `pubspec.yaml` version will still be updated.                                                      | `true`  |
+| `useVersionCode` | Whether to write version code for every newly bumped version in `pubspec.yaml` ([Learn more](https://developer.android.com/studio/publish/versioning#versioningsettings)) | `false` |
 
 ### Examples
 

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -3,13 +3,16 @@ import { PrepareContext } from "semantic-release";
 import { parse } from "yaml";
 import { Pubspec } from "./schemas.js";
 import { PluginConfig } from "./types.js";
+import { getConfig } from "./utils.js";
 
 const PUBSPEC_PATH = "pubspec.yaml";
 
 export const prepare = async (
-  _pluginConfig: PluginConfig,
+  pluginConfig: PluginConfig,
   { nextRelease: { version }, logger }: PrepareContext,
 ) => {
+  const { useVersionCode } = getConfig(pluginConfig);
+
   const data = readFileSync(PUBSPEC_PATH, "utf-8");
   const pubspec = Pubspec.parse(parse(data));
   const pubspecVersionEscaped = pubspec.version.replace(
@@ -17,9 +20,24 @@ export const prepare = async (
     "\\$&",
   );
 
+  let nextVersion = version;
+  if (useVersionCode) {
+    const versionCodeString =
+      pubspec.version.indexOf("+") >= 0 ? pubspec.version.split("+")[1] : "0";
+
+    const versionCode = Number(versionCodeString);
+    if (isNaN(versionCode)) {
+      throw new Error(
+        `Invalid version code: ${versionCodeString} in ${pubspec.version}`,
+      );
+    }
+
+    nextVersion = `${version}+${versionCode + 1}`;
+  }
+
   const newData = data.replace(
     new RegExp(`version:[ \t]+${pubspecVersionEscaped}`),
-    `version: ${version}`,
+    `version: ${nextVersion}`,
   );
 
   logger.log(`Writing version ${version} to ${PUBSPEC_PATH}`);

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -1,6 +1,8 @@
 import { readFileSync, writeFileSync } from "fs";
-import { PrepareContext } from "semantic-release";
 import { parse } from "yaml";
+import { PrepareContext } from "semantic-release";
+import SemanticReleaseError from "@semantic-release/error";
+
 import { Pubspec } from "./schemas.js";
 import { PluginConfig } from "./types.js";
 import { getConfig } from "./utils.js";
@@ -22,17 +24,16 @@ export const prepare = async (
 
   let nextVersion = version;
   if (updateBuildNumber) {
-    const versionCodeString =
-      pubspec.version.indexOf("+") >= 0 ? pubspec.version.split("+")[1] : "0";
+    const parts = pubspec.version.split("+");
+    const buildNumber = parts.length > 1 ? Number(parts[1]) : 0;
 
-    const versionCode = Number(versionCodeString);
-    if (isNaN(versionCode)) {
-      throw new Error(
-        `Invalid version code: ${versionCodeString} in ${pubspec.version}`,
+    if (isNaN(buildNumber)) {
+      throw new SemanticReleaseError(
+        `Invalid build number: ${buildNumber} in ${pubspec.version}`,
       );
     }
 
-    nextVersion = `${version}+${versionCode + 1}`;
+    nextVersion = `${version}+${buildNumber + 1}`;
   }
 
   const newData = data.replace(

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -41,6 +41,6 @@ export const prepare = async (
     `version: ${nextVersion}`,
   );
 
-  logger.log(`Writing version ${version} to ${PUBSPEC_PATH}`);
+  logger.log(`Writing version ${nextVersion} to ${PUBSPEC_PATH}`);
   writeFileSync(PUBSPEC_PATH, newData);
 };

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -11,7 +11,7 @@ export const prepare = async (
   pluginConfig: PluginConfig,
   { nextRelease: { version }, logger }: PrepareContext,
 ) => {
-  const { useVersionCode } = getConfig(pluginConfig);
+  const { updateBuildNumber } = getConfig(pluginConfig);
 
   const data = readFileSync(PUBSPEC_PATH, "utf-8");
   const pubspec = Pubspec.parse(parse(data));
@@ -21,7 +21,7 @@ export const prepare = async (
   );
 
   let nextVersion = version;
-  if (useVersionCode) {
+  if (updateBuildNumber) {
     const versionCodeString =
       pubspec.version.indexOf("+") >= 0 ? pubspec.version.split("+")[1] : "0";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type PluginConfig = {
   cli: "dart" | "flutter";
   publishPub: boolean;
-  useVersionCode: boolean;
+  updateBuildNumber: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type PluginConfig = {
   cli: "dart" | "flutter";
   publishPub: boolean;
+  useVersionCode: boolean;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import { PluginConfig } from "./types.js";
 const DEFAULT_CONFIG: PluginConfig = {
   cli: "dart",
   publishPub: true,
-  useVersionCode: false,
+  updateBuildNumber: false,
 };
 
 const PUB_DEV_AUDIENCE = "https://pub.dev";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { PluginConfig } from "./types.js";
 const DEFAULT_CONFIG: PluginConfig = {
   cli: "dart",
   publishPub: true,
+  useVersionCode: false,
 };
 
 const PUB_DEV_AUDIENCE = "https://pub.dev";

--- a/tests/prepare.test.ts
+++ b/tests/prepare.test.ts
@@ -16,7 +16,11 @@ describe("prepare", () => {
   const pubspecPath = "pubspec.yaml";
   const cli = "dart";
 
-  const config: PluginConfig = { cli, publishPub: true, useVersionCode: false };
+  const config: PluginConfig = {
+    cli,
+    publishPub: true,
+    updateBuildNumber: false,
+  };
 
   const basePubspec = codeBlock`
     name: pub_package
@@ -67,8 +71,8 @@ describe("prepare", () => {
     },
   );
 
-  test("success with pubspec version with version code (useVersionCode = true)", async () => {
-    const newConfig = { ...config, useVersionCode: true };
+  test("success with pubspec version with version code (updateBuildNumber = true)", async () => {
+    const newConfig = { ...config, updateBuildNumber: true };
     const pubspec = basePubspec.replace(
       new RegExp(versionPlaceholder),
       `${newVersion}+1`,
@@ -86,8 +90,8 @@ describe("prepare", () => {
     expect(writeFileSync).toHaveBeenNthCalledWith(1, pubspecPath, newPubspec);
   });
 
-  test(`success with pubspec version without version code (useVersionCode = true)`, async () => {
-    const newConfig = { ...config, useVersionCode: true };
+  test(`success with pubspec version without version code (updateBuildNumber = true)`, async () => {
+    const newConfig = { ...config, updateBuildNumber: true };
     const pubspec = basePubspec.replace(
       new RegExp(versionPlaceholder),
       `${newVersion}`,
@@ -106,7 +110,7 @@ describe("prepare", () => {
   });
 
   test("error due to invalid version code", async () => {
-    const newConfig = { ...config, useVersionCode: true };
+    const newConfig = { ...config, updateBuildNumber: true };
     const pubspec = basePubspec.replace(
       new RegExp(versionPlaceholder),
       `${newVersion}+invalid`,

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -16,7 +16,11 @@ describe("publish", () => {
   const version = "1.2.3";
   const semanticReleasePubToken = "SEMANTIC_RELEASE_PUB_TOKEN";
 
-  const config: PluginConfig = { cli, publishPub: true, useVersionCode: false };
+  const config: PluginConfig = {
+    cli,
+    publishPub: true,
+    updateBuildNumber: false,
+  };
   const nextRelease = mock<NextRelease>();
   const logger = mock<Signale>();
   const context = mock<PublishContext>();

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -16,7 +16,7 @@ describe("publish", () => {
   const version = "1.2.3";
   const semanticReleasePubToken = "SEMANTIC_RELEASE_PUB_TOKEN";
 
-  const config: PluginConfig = { cli, publishPub: true };
+  const config: PluginConfig = { cli, publishPub: true, useVersionCode: false };
   const nextRelease = mock<NextRelease>();
   const logger = mock<Signale>();
   const context = mock<PublishContext>();

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -12,7 +12,7 @@ describe("getConfig", () => {
   const config: PluginConfig = {
     cli: "flutter",
     publishPub: false,
-    useVersionCode: false,
+    updateBuildNumber: false,
   };
 
   test("success", () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -12,6 +12,7 @@ describe("getConfig", () => {
   const config: PluginConfig = {
     cli: "flutter",
     publishPub: false,
+    useVersionCode: false,
   };
 
   test("success", () => {

--- a/tests/verifyConditions.test.ts
+++ b/tests/verifyConditions.test.ts
@@ -16,7 +16,11 @@ describe("verifyConditions", () => {
   const serviceAccount = "serviceAccount";
   const idToken = "idToken";
 
-  const config: PluginConfig = { cli, publishPub: true, useVersionCode: false };
+  const config: PluginConfig = {
+    cli,
+    publishPub: true,
+    updateBuildNumber: false,
+  };
 
   const logger = mock<Signale>();
   const context = mock<VerifyConditionsContext>();

--- a/tests/verifyConditions.test.ts
+++ b/tests/verifyConditions.test.ts
@@ -16,7 +16,7 @@ describe("verifyConditions", () => {
   const serviceAccount = "serviceAccount";
   const idToken = "idToken";
 
-  const config: PluginConfig = { cli, publishPub: true };
+  const config: PluginConfig = { cli, publishPub: true, useVersionCode: false };
 
   const logger = mock<Signale>();
   const context = mock<VerifyConditionsContext>();


### PR DESCRIPTION
## Summary

This PR resolves #152.

this PR will add increasing version code support for every version bump. This will change version code like these:

### Without version code

```diff
- version: 1.0.0
+ version: 1.0.1+1
```

### With version code

```diff
- version: 1.0.0+1
+ version: 1.0.1+2
```

version code will be increased by 1 on every bumps.

## Config

I've added `useVersionCode` field on configuration because I thought I should add configuration field to set whether use version code or not. (since some of users wouldn't want to use version codes on their own pub packages)


| Option           | Description                                                                                                                                                               | Default |
|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
| `useVersionCode` | Whether to write version code for every newly bumped version in `pubspec.yaml` ([Learn more](https://developer.android.com/studio/publish/versioning#versioningsettings)) | `false` |
