### PR TITLE
Revert "chore(deps): update dependency conventional-changelog-conventionalcommits to v8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@typescript-eslint/parser": "7.8.0",
     "@vitest/coverage-v8": "1.6.0",
     "common-tags": "1.8.2",
-    "conventional-changelog-conventionalcommits": "8.0.0",
+    "conventional-changelog-conventionalcommits": "7.0.2",
     "eslint": "8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-semistandard": "17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,10 +1580,10 @@ conventional-changelog-angular@^7.0.0:
   dependencies:
     compare-func "^2.0.0"
 
-conventional-changelog-conventionalcommits@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz#3fa2857c878701e7f0329db5a1257cb218f166fe"
-  integrity sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==
+conventional-changelog-conventionalcommits@7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz#aa5da0f1b2543094889e8cf7616ebe1a8f5c70d5"
+  integrity sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==
   dependencies:
     compare-func "^2.0.0"
 


### PR DESCRIPTION
Reverts zeshuaro/semantic-release-pub#324

Because of compatible issue with `semantic-release`: https://github.com/semantic-release/release-notes-generator/issues/633