### PR TITLE
fix: preserve existing build number when updateBuildNumber is false

### DIFF
--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -36,6 +36,11 @@ export const prepare = async (
     }
 
     nextVersion = `${version}+${buildNumber + 1}`;
+  } else {
+    const parts = pubspec.version.split("+");
+    if (parts.length > 1) {
+      nextVersion = `${version}+${parts[1]}`;
+    }
   }
 
   const newData = data.replace(

--- a/tests/prepare.test.ts
+++ b/tests/prepare.test.ts
@@ -63,7 +63,6 @@ describe("prepare", () => {
     oldVersion,
     oldVersionSingleQuoted,
     oldVersionDoubleQuoted,
-    oldVersionWithBuild,
   ])("success with pubspec version %s", async (version) => {
     const pubspec = basePubspec.replace(
       new RegExp(versionPlaceholder),
@@ -98,6 +97,28 @@ describe("prepare", () => {
       1,
       pkgRootPubspecPath,
       newPubspec,
+    );
+  });
+
+  test("success preserves build number when updateBuildNumber is false", async () => {
+    const pubspec = basePubspec.replace(
+      new RegExp(versionPlaceholder),
+      oldVersionWithBuild,
+    );
+    vi.mocked(readFileSync).mockReturnValue(pubspec);
+
+    await prepare(config, context);
+
+    const expectedPubspec = basePubspec.replace(
+      new RegExp(versionPlaceholder),
+      `${newVersion}+1`,
+    );
+
+    expect(readFileSync).toHaveBeenNthCalledWith(1, pubspecPath, "utf-8");
+    expect(writeFileSync).toHaveBeenNthCalledWith(
+      1,
+      pubspecPath,
+      expectedPubspec,
     );
   });
 


### PR DESCRIPTION
## Problem

When a pubspec version includes a build number (e.g. `1.0.0+5`) and `updateBuildNumber` is `false`, the plugin replaces the full version string with just the semantic version (`1.0.0`), silently discarding the build suffix on every release.

## Fix

Carry the existing build number suffix forward into the new version when `updateBuildNumber` is `false`, so the suffix is preserved between releases.

```
before: version 1.0.0+5, new release → writes version: 1.1.0   (build number lost)
after:  version 1.0.0+5, new release → writes version: 1.1.0+5 (build number preserved)
```

## Changes

- `src/prepare.ts` — preserve build suffix in the `updateBuildNumber = false` path
- `tests/prepare.test.ts` — dedicated test covering the preservation behaviour; removed `oldVersionWithBuild` from the generic test.each case that expected stripping

Closes #544