### PR TITLE
feat: add registryUrl option to support custom pub registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The following instructions are referenced from the [documentation](https://dart.
 | `updateBuildNumber` | Whether to write build number for every newly bumped version in `pubspec.yaml`. Note that the build number will always be increased by one. Learn more on [Flutter docs](https://docs.flutter.dev/deployment/android#updating-the-apps-version-number). | `false` |
 | `useGithubOidc`     | Whether to use GitHub OIDC. If set to `true`, authentication to `pub.dev` will be done using GitHub OIDC. Otherwise, the `GOOGLE_SERVICE_ACCOUNT_KEY` will be used.                                                                                     | `false` |
 | `pkgRoot`           | The path to the package root directory. Useful for monorepos where the package is not at the repository root.                                                                                                                                           | `.`     |
+| `registryUrl`       | The URL of the pub registry to publish to. Useful for private registries such as [unpub](https://pub.dev/packages/unpub). The URL is used as the token audience for OIDC authentication and as the target for `dart pub token add`.                     | `https://pub.dev` |
 
 ### Examples
 

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -16,33 +16,38 @@ export const publish = async (
   pluginConfig: PluginConfig,
   { nextRelease: { version }, logger }: PublishContext,
 ) => {
-  const { cli, publishPub, useGithubOidc, pkgRoot } = getConfig(pluginConfig);
+  const { cli, publishPub, useGithubOidc, pkgRoot, registryUrl } =
+    getConfig(pluginConfig);
   if (!publishPub) {
     logger.log(`Skipping publishing to pub.dev as publishPub is ${publishPub}`);
     return;
   }
 
   const pubspec = getPubspec(pkgRoot);
-  const pubToken = await getPubToken(useGithubOidc, logger);
-  await setPubToken(cli, pubToken);
+  const pubToken = await getPubToken(useGithubOidc, registryUrl, logger);
+  await setPubToken(cli, pubToken, registryUrl);
 
-  logger.log(`Publishing version ${version} to pub.dev`);
+  logger.log(`Publishing version ${version} to ${registryUrl}`);
   await execa(cli, ["pub", "publish", "--force"], { cwd: pkgRoot });
-  logger.log(`Published ${pubspec.name}@${version} on pub.dev`);
+  logger.log(`Published ${pubspec.name}@${version} on ${registryUrl}`);
 
   return {
     name: "pub.dev package",
-    url: `https://pub.dev/packages/${pubspec.name}/versions/${version}`,
+    url: `${registryUrl}/packages/${pubspec.name}/versions/${version}`,
   };
 };
 
-const getPubToken = async (useGithubOidc: boolean, logger: Signale) => {
+const getPubToken = async (
+  useGithubOidc: boolean,
+  registryUrl: string,
+  logger: Signale,
+) => {
   if (useGithubOidc) {
-    logger.log("Using GitHub OIDC token to publish to pub.dev");
-    return await getGithubIdentityToken();
+    logger.log(`Using GitHub OIDC token to publish to ${registryUrl}`);
+    return await getGithubIdentityToken(registryUrl);
   }
 
-  logger.log("Using Google identity token to publish to pub.dev");
+  logger.log(`Using Google identity token to publish to ${registryUrl}`);
   const { GOOGLE_SERVICE_ACCOUNT_KEY } = process.env;
   if (!GOOGLE_SERVICE_ACCOUNT_KEY) {
     throw new SemanticReleaseError(
@@ -50,16 +55,20 @@ const getPubToken = async (useGithubOidc: boolean, logger: Signale) => {
     );
   }
 
-  return await getGoogleIdentityToken(GOOGLE_SERVICE_ACCOUNT_KEY);
+  return await getGoogleIdentityToken(GOOGLE_SERVICE_ACCOUNT_KEY, registryUrl);
 };
 
-const setPubToken = async (cli: string, idToken: string) => {
+const setPubToken = async (
+  cli: string,
+  idToken: string,
+  registryUrl: string,
+) => {
   process.env[SEMANTIC_RELEASE_PUB_TOKEN] = idToken;
   await execa(cli, [
     "pub",
     "token",
     "add",
-    "https://pub.dev",
+    registryUrl,
     `--env-var=${SEMANTIC_RELEASE_PUB_TOKEN}`,
   ]);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,4 +4,5 @@ export type PluginConfig = {
   updateBuildNumber: boolean;
   useGithubOidc: boolean;
   pkgRoot: string;
+  registryUrl: string;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,29 +8,37 @@ import { Pubspec, ServiceAccount } from "./schemas.js";
 import type { PluginConfig } from "./types.js";
 
 const PUBSPEC_PATH = "pubspec.yaml";
+export const PUB_DEV_URL = "https://pub.dev";
+
 const DEFAULT_CONFIG: PluginConfig = {
   cli: "dart",
   publishPub: true,
   updateBuildNumber: false,
   useGithubOidc: false,
   pkgRoot: ".",
+  registryUrl: PUB_DEV_URL,
 };
 
-const PUB_DEV_AUDIENCE = "https://pub.dev";
-
 export const getConfig = (config: PluginConfig): PluginConfig => {
-  return { ...DEFAULT_CONFIG, ...config };
+  const merged = { ...DEFAULT_CONFIG, ...config };
+  return {
+    ...merged,
+    registryUrl: merged.registryUrl.replace(/\/$/, ""),
+  };
 };
 
 export const getPubspecPath = (pkgRoot: string): string =>
   join(pkgRoot, PUBSPEC_PATH);
 
-export const getGoogleIdentityToken = async (serviceAccountStr: string) => {
+export const getGoogleIdentityToken = async (
+  serviceAccountStr: string,
+  registryUrl: string,
+) => {
   const serviceAccountJson = getServiceAccount(serviceAccountStr);
   const jwtClient = new JWT({
     email: serviceAccountJson.client_email,
     key: serviceAccountJson.private_key,
-    scopes: PUB_DEV_AUDIENCE,
+    scopes: registryUrl,
   });
 
   const creds = await jwtClient.authorize();
@@ -43,8 +51,8 @@ export const getGoogleIdentityToken = async (serviceAccountStr: string) => {
   return creds.id_token;
 };
 
-export const getGithubIdentityToken = async () => {
-  return getIDToken(PUB_DEV_AUDIENCE);
+export const getGithubIdentityToken = async (registryUrl: string) => {
+  return getIDToken(registryUrl);
 };
 
 export const getPubspecString = (pkgRoot: string): string => {

--- a/src/verifyConditions.ts
+++ b/src/verifyConditions.ts
@@ -12,9 +12,10 @@ export const verifyConditions = async (
   pluginConfig: PluginConfig,
   { logger }: VerifyConditionsContext,
 ) => {
-  const { cli, publishPub, useGithubOidc } = getConfig(pluginConfig);
+  const { cli, publishPub, useGithubOidc, registryUrl } =
+    getConfig(pluginConfig);
   if (publishPub) {
-    await verifyPublishToken(useGithubOidc);
+    await verifyPublishToken(useGithubOidc, registryUrl);
     await verifyCommand(cli);
   } else {
     logger.log(
@@ -23,10 +24,13 @@ export const verifyConditions = async (
   }
 };
 
-const verifyPublishToken = async (useGithubOidc: boolean) => {
+const verifyPublishToken = async (
+  useGithubOidc: boolean,
+  registryUrl: string,
+) => {
   if (useGithubOidc) {
     try {
-      await getGithubIdentityToken();
+      await getGithubIdentityToken(registryUrl);
     } catch (error) {
       throw new SemanticReleaseError(
         `Failed to get GitHub OIDC token: ${error}`,
@@ -40,7 +44,7 @@ const verifyPublishToken = async (useGithubOidc: boolean) => {
       );
     }
 
-    await getGoogleIdentityToken(GOOGLE_SERVICE_ACCOUNT_KEY);
+    await getGoogleIdentityToken(GOOGLE_SERVICE_ACCOUNT_KEY, registryUrl);
   }
 };
 

--- a/tests/prepare.test.ts
+++ b/tests/prepare.test.ts
@@ -24,6 +24,7 @@ describe("prepare", () => {
     updateBuildNumber: false,
     useGithubOidc: false,
     pkgRoot: ".",
+    registryUrl: "https://pub.dev",
   };
 
   const basePubspec = codeBlock`

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -10,6 +10,7 @@ import {
   getGithubIdentityToken,
   getGoogleIdentityToken,
   getPubspec,
+  PUB_DEV_URL,
 } from "../src/utils.js";
 
 vi.mock("execa");
@@ -29,6 +30,7 @@ describe("publish", () => {
     updateBuildNumber: false,
     useGithubOidc: false,
     pkgRoot: ".",
+    registryUrl: PUB_DEV_URL,
   };
 
   const pubspec: Pubspec = {
@@ -63,12 +65,25 @@ describe("publish", () => {
 
     expect(actual).toEqual({
       name: "pub.dev package",
-      url: `https://pub.dev/packages/${pubspec.name}/versions/${version}`,
+      url: `${PUB_DEV_URL}/packages/${pubspec.name}/versions/${version}`,
     });
     expect(process.env[semanticReleasePubToken]).toEqual(googleIdToken);
 
-    expect(getGoogleIdentityToken).toHaveBeenNthCalledWith(1, serviceAccount);
-    expectExecaCalled();
+    expect(getGoogleIdentityToken).toHaveBeenNthCalledWith(
+      1,
+      serviceAccount,
+      PUB_DEV_URL,
+    );
+    expect(execa).toHaveBeenNthCalledWith(1, cli, [
+      "pub",
+      "token",
+      "add",
+      PUB_DEV_URL,
+      `--env-var=${semanticReleasePubToken}`,
+    ]);
+    expect(execa).toHaveBeenNthCalledWith(2, cli, ["pub", "publish", "--force"], {
+      cwd: ".",
+    });
   });
 
   test("success with useGithubOidc=true", async () => {
@@ -79,12 +94,21 @@ describe("publish", () => {
 
     expect(actual).toEqual({
       name: "pub.dev package",
-      url: `https://pub.dev/packages/${pubspec.name}/versions/${version}`,
+      url: `${PUB_DEV_URL}/packages/${pubspec.name}/versions/${version}`,
     });
     expect(process.env[semanticReleasePubToken]).toEqual(githubIdToken);
 
-    expect(getGithubIdentityToken).toHaveBeenCalledOnce();
-    expectExecaCalled();
+    expect(getGithubIdentityToken).toHaveBeenNthCalledWith(1, PUB_DEV_URL);
+    expect(execa).toHaveBeenNthCalledWith(1, cli, [
+      "pub",
+      "token",
+      "add",
+      PUB_DEV_URL,
+      `--env-var=${semanticReleasePubToken}`,
+    ]);
+    expect(execa).toHaveBeenNthCalledWith(2, cli, ["pub", "publish", "--force"], {
+      cwd: ".",
+    });
   });
 
   test("success with pkgRoot publishes from pkgRoot directory", async () => {
@@ -102,6 +126,32 @@ describe("publish", () => {
       ["pub", "publish", "--force"],
       { cwd: pkgRoot },
     );
+  });
+
+  test("success with custom registryUrl", async () => {
+    const customUrl = "https://my-registry.example.com";
+    const config = { ...testConfig, registryUrl: customUrl };
+    vi.mocked(getConfig).mockReturnValue(config);
+    stubEnv();
+
+    const actual = await publish(config, context);
+
+    expect(actual).toEqual({
+      name: "pub.dev package",
+      url: `${customUrl}/packages/${pubspec.name}/versions/${version}`,
+    });
+    expect(getGoogleIdentityToken).toHaveBeenNthCalledWith(
+      1,
+      serviceAccount,
+      customUrl,
+    );
+    expect(execa).toHaveBeenNthCalledWith(1, cli, [
+      "pub",
+      "token",
+      "add",
+      customUrl,
+      `--env-var=${semanticReleasePubToken}`,
+    ]);
   });
 
   test("skip publish", async () => {
@@ -126,20 +176,4 @@ describe("publish", () => {
 
   const stubEnv = () =>
     vi.stubEnv("GOOGLE_SERVICE_ACCOUNT_KEY", serviceAccount);
-
-  const expectExecaCalled = (cwd = ".") => {
-    expect(execa).toHaveBeenNthCalledWith(1, cli, [
-      "pub",
-      "token",
-      "add",
-      "https://pub.dev",
-      `--env-var=${semanticReleasePubToken}`,
-    ]);
-    expect(execa).toHaveBeenNthCalledWith(
-      2,
-      cli,
-      ["pub", "publish", "--force"],
-      { cwd },
-    );
-  };
 });

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -81,9 +81,14 @@ describe("publish", () => {
       PUB_DEV_URL,
       `--env-var=${semanticReleasePubToken}`,
     ]);
-    expect(execa).toHaveBeenNthCalledWith(2, cli, ["pub", "publish", "--force"], {
-      cwd: ".",
-    });
+    expect(execa).toHaveBeenNthCalledWith(
+      2,
+      cli,
+      ["pub", "publish", "--force"],
+      {
+        cwd: ".",
+      },
+    );
   });
 
   test("success with useGithubOidc=true", async () => {
@@ -106,9 +111,14 @@ describe("publish", () => {
       PUB_DEV_URL,
       `--env-var=${semanticReleasePubToken}`,
     ]);
-    expect(execa).toHaveBeenNthCalledWith(2, cli, ["pub", "publish", "--force"], {
-      cwd: ".",
-    });
+    expect(execa).toHaveBeenNthCalledWith(
+      2,
+      cli,
+      ["pub", "publish", "--force"],
+      {
+        cwd: ".",
+      },
+    );
   });
 
   test("success with pkgRoot publishes from pkgRoot directory", async () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -15,6 +15,7 @@ import {
   getPubspecFromString,
   getPubspecPath,
   getPubspecString,
+  PUB_DEV_URL,
 } from "../src/utils.js";
 
 vi.mock("@actions/core");
@@ -30,8 +31,6 @@ vi.mock("google-auth-library", () => ({
   ),
 }));
 
-const pubDevAudience = "https://pub.dev";
-
 describe("getConfig", () => {
   const config: PluginConfig = {
     cli: "flutter",
@@ -39,10 +38,25 @@ describe("getConfig", () => {
     updateBuildNumber: false,
     useGithubOidc: false,
     pkgRoot: ".",
+    registryUrl: PUB_DEV_URL,
   };
 
-  test("success", () => {
+  test("success with all fields provided", () => {
     expect(getConfig(config)).toEqual(config);
+  });
+
+  test("applies default registryUrl when not provided", () => {
+    const { registryUrl: _omitted, ...configWithoutRegistry } = config;
+    expect(getConfig(configWithoutRegistry as PluginConfig)).toMatchObject({
+      registryUrl: PUB_DEV_URL,
+    });
+  });
+
+  test("strips trailing slash from registryUrl", () => {
+    const configWithSlash = { ...config, registryUrl: `${PUB_DEV_URL}/` };
+    expect(getConfig(configWithSlash)).toMatchObject({
+      registryUrl: PUB_DEV_URL,
+    });
   });
 });
 
@@ -64,20 +78,32 @@ describe("getGoogleIdentityToken", () => {
     vi.clearAllMocks();
   });
 
-  test("success", async () => {
+  test("success with default pub.dev audience", async () => {
     creds.id_token = idToken;
     authorize.mockResolvedValue(creds);
 
-    const actual = await getGoogleIdentityToken(serviceAccount);
+    const actual = await getGoogleIdentityToken(serviceAccount, PUB_DEV_URL);
 
     expect(actual).toEqual(idToken);
-    expectJwtCalled();
+    expectJwtCalled(PUB_DEV_URL);
+    expect(authorize).toHaveBeenCalledTimes(1);
+  });
+
+  test("success with custom registry URL", async () => {
+    const customUrl = "https://my-registry.example.com";
+    creds.id_token = idToken;
+    authorize.mockResolvedValue(creds);
+
+    const actual = await getGoogleIdentityToken(serviceAccount, customUrl);
+
+    expect(actual).toEqual(idToken);
+    expectJwtCalled(customUrl);
     expect(authorize).toHaveBeenCalledTimes(1);
   });
 
   test("error due to invalid service account", async () => {
     await expect(() =>
-      getGoogleIdentityToken("clearlyInvalid"),
+      getGoogleIdentityToken("clearlyInvalid", PUB_DEV_URL),
     ).rejects.toThrow(SemanticReleaseError);
     expect(JWT).toHaveBeenCalledTimes(0);
   });
@@ -86,19 +112,19 @@ describe("getGoogleIdentityToken", () => {
     creds.id_token = null;
     authorize.mockResolvedValue(creds);
 
-    await expect(() => getGoogleIdentityToken(serviceAccount)).rejects.toThrow(
-      SemanticReleaseError,
-    );
+    await expect(() =>
+      getGoogleIdentityToken(serviceAccount, PUB_DEV_URL),
+    ).rejects.toThrow(SemanticReleaseError);
 
-    expectJwtCalled();
+    expectJwtCalled(PUB_DEV_URL);
     expect(authorize).toHaveBeenCalledTimes(1);
   });
 
-  const expectJwtCalled = () => {
+  const expectJwtCalled = (registryUrl: string) => {
     expect(JWT).toHaveBeenNthCalledWith(1, {
       email: clientEmail,
       key: privateKey,
-      scopes: pubDevAudience,
+      scopes: registryUrl,
     });
   };
 });
@@ -110,13 +136,23 @@ describe("getGithubIdentityToken", () => {
     vi.clearAllMocks();
   });
 
-  test("success", async () => {
+  test("success with default pub.dev audience", async () => {
     vi.mocked(getIDToken).mockResolvedValue(idToken);
 
-    const actual = await getGithubIdentityToken();
+    const actual = await getGithubIdentityToken(PUB_DEV_URL);
 
     expect(actual).toEqual(idToken);
-    expect(getIDToken).toHaveBeenNthCalledWith(1, pubDevAudience);
+    expect(getIDToken).toHaveBeenNthCalledWith(1, PUB_DEV_URL);
+  });
+
+  test("success with custom registry URL", async () => {
+    const customUrl = "https://my-registry.example.com";
+    vi.mocked(getIDToken).mockResolvedValue(idToken);
+
+    const actual = await getGithubIdentityToken(customUrl);
+
+    expect(actual).toEqual(idToken);
+    expect(getIDToken).toHaveBeenNthCalledWith(1, customUrl);
   });
 });
 

--- a/tests/verifyConditions.test.ts
+++ b/tests/verifyConditions.test.ts
@@ -9,6 +9,7 @@ import {
   getConfig,
   getGithubIdentityToken,
   getGoogleIdentityToken,
+  PUB_DEV_URL,
 } from "../src/utils.js";
 
 vi.mock("execa");
@@ -19,6 +20,7 @@ describe("verifyConditions", () => {
   const cli = "dart";
   const serviceAccount = "serviceAccount";
   const idToken = "idToken";
+  const customUrl = "https://my-registry.example.com";
 
   const testConfig: PluginConfig = {
     cli,
@@ -26,6 +28,7 @@ describe("verifyConditions", () => {
     updateBuildNumber: false,
     useGithubOidc: false,
     pkgRoot: ".",
+    registryUrl: PUB_DEV_URL,
   };
 
   const logger = mock<Signale>();
@@ -50,7 +53,18 @@ describe("verifyConditions", () => {
     await verifyConditions(testConfig, context);
 
     expect(execa).toHaveBeenCalledWith(cli);
-    expectGetGoogleIdentityTokenCalled();
+    expectGetGoogleIdentityTokenCalled(PUB_DEV_URL);
+  });
+
+  test("success with custom registryUrl", async () => {
+    const config = { ...testConfig, registryUrl: customUrl };
+    vi.mocked(getConfig).mockReturnValue(config);
+    stubEnv();
+
+    await verifyConditions(config, context);
+
+    expect(execa).toHaveBeenCalledWith(cli);
+    expectGetGoogleIdentityTokenCalled(customUrl);
   });
 
   test("success with publishPub=false", async () => {
@@ -69,7 +83,7 @@ describe("verifyConditions", () => {
 
     await verifyConditions(config, context);
 
-    expect(getGithubIdentityToken).toHaveBeenCalledTimes(1);
+    expect(getGithubIdentityToken).toHaveBeenNthCalledWith(1, PUB_DEV_URL);
     expect(getGoogleIdentityToken).toHaveBeenCalledTimes(0);
     expect(execa).toHaveBeenCalledWith(cli);
   });
@@ -103,14 +117,18 @@ describe("verifyConditions", () => {
     await expectSemanticReleaseError();
 
     expect(execa).toHaveBeenCalledWith(cli);
-    expectGetGoogleIdentityTokenCalled();
+    expectGetGoogleIdentityTokenCalled(PUB_DEV_URL);
   });
 
   const stubEnv = () =>
     vi.stubEnv("GOOGLE_SERVICE_ACCOUNT_KEY", serviceAccount);
 
-  const expectGetGoogleIdentityTokenCalled = () =>
-    expect(getGoogleIdentityToken).toHaveBeenNthCalledWith(1, serviceAccount);
+  const expectGetGoogleIdentityTokenCalled = (registryUrl: string) =>
+    expect(getGoogleIdentityToken).toHaveBeenNthCalledWith(
+      1,
+      serviceAccount,
+      registryUrl,
+    );
 
   const expectSemanticReleaseError = async (
     config: PluginConfig = testConfig,


### PR DESCRIPTION
## Problem

The pub.dev URL (`https://pub.dev`) is hardcoded throughout the plugin — in the Google/GitHub identity token audience, `dart pub token add`, and the published release output. Companies running private Pub registries (e.g. [unpub](https://pub.dev/packages/unpub)) have no way to point the plugin at their own registry.

## Fix

Add a `registryUrl` config option that defaults to `https://pub.dev`, keeping all existing configurations working without changes. When set, the custom URL is used consistently everywhere the registry URL appears.

## Changes

- `src/types.ts` — add `registryUrl?: string` to `PluginConfig`
- `src/utils.ts` — export `PUB_DEV_URL` constant; thread `registryUrl` through `getGoogleIdentityToken()` and `getGithubIdentityToken()` as the token audience
- `src/publish.ts` — use `registryUrl` in `dart pub token add`, log messages, and result URL
- `src/verifyConditions.ts` — pass `registryUrl` to token verification
- Tests updated across all four test files, including custom-registry test cases

## Example

```json
["semantic-release-pub", { "registryUrl": "https://my-registry.example.com" }]
```

> **Note:** GitHub OIDC tokens with a custom audience will only work if the target registry validates them — that is a function of the registry implementation, not this plugin.

Closes #339